### PR TITLE
perf(scraper): incremental scraping with retries and bounded concurrency

### DIFF
--- a/.github/workflows/scrape-recipes.yml
+++ b/.github/workflows/scrape-recipes.yml
@@ -1,7 +1,12 @@
 name: Scrape recipes
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      full:
+        description: 'Re-scrape every recipe (full) instead of incremental'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -20,7 +25,7 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
-      - run: yarn scraper
+      - run: ${{ inputs.full && 'yarn scraper:full' || 'yarn scraper' }}
 
       - name: Check for changes
         id: git-check

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start": "webpack-dev-server --config ./build/webpack.config.dev.js",
     "build": "webpack --config ./build/webpack.config.prod.js",
     "scraper": "node ./utils/node-scraper/script.js",
+    "scraper:full": "node ./utils/node-scraper/script.js --full",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/utils/node-scraper/modules/http.js
+++ b/utils/node-scraper/modules/http.js
@@ -1,0 +1,106 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+const USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+
+const client = axios.create({
+  timeout: 15000,
+  headers: {
+    'User-Agent': USER_AGENT,
+    'Accept-Language': 'es-ES,es;q=0.9',
+  },
+});
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * True for errors worth retrying: network hiccups, timeouts and
+ * transient server responses (429 / 5xx). Anything else (e.g. 404) is
+ * considered definitive and not retried.
+ */
+const isTransientError = (error) => {
+  const transientCodes = [
+    'ECONNRESET',
+    'ETIMEDOUT',
+    'ECONNABORTED',
+    'EAI_AGAIN',
+  ];
+  if (error.code && transientCodes.includes(error.code)) {
+    return true;
+  }
+
+  const status = error.response && error.response.status;
+  if (status === 429 || (status >= 500 && status <= 599)) {
+    return true;
+  }
+
+  // No response at all usually means the request never completed.
+  return !error.response;
+};
+
+/**
+ * Runs `fn` and retries it with exponential backoff + jitter while the
+ * error looks transient. Rethrows the last error once retries are exhausted.
+ */
+const fetchWithRetry = async (fn, { retries = 3, baseDelay = 500 } = {}) => {
+  let attempt = 0;
+
+  for (;;) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt >= retries || !isTransientError(error)) {
+        throw error;
+      }
+
+      const backoff = baseDelay * 2 ** attempt;
+      const jitter = Math.floor(Math.random() * baseDelay);
+      await sleep(backoff + jitter);
+      attempt += 1;
+    }
+  }
+};
+
+/**
+ * Fetches a URL and returns a loaded cheerio instance. Wrapped in
+ * `fetchWithRetry` so callers get transparent retries.
+ */
+const fetchHtml = (url, retryOptions) =>
+  fetchWithRetry(async () => {
+    const response = await client.get(encodeURI(url));
+    return cheerio.load(response.data);
+  }, retryOptions);
+
+/**
+ * Maps `items` through the async `fn` with a bounded number of concurrent
+ * workers, preserving input order in the result. A rejected `fn` aborts the
+ * whole run, so callers that want per-item tolerance must not throw.
+ */
+const mapWithConcurrency = async (items, limit, fn) => {
+  const results = new Array(items.length);
+  let cursor = 0;
+
+  const worker = async () => {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) {
+        return;
+      }
+      results[index] = await fn(items[index], index);
+    }
+  };
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, worker);
+  await Promise.all(workers);
+
+  return results;
+};
+
+module.exports = {
+  client,
+  fetchHtml,
+  fetchWithRetry,
+  mapWithConcurrency,
+};

--- a/utils/node-scraper/modules/recipe-data.js
+++ b/utils/node-scraper/modules/recipe-data.js
@@ -1,71 +1,75 @@
-const axios = require('axios');
-const cheerio = require('cheerio');
+const { fetchHtml } = require('./http');
 
+/**
+ * Fetches a single recipe page and extracts its extra data
+ * (difficulty, rations, time, image).
+ *
+ * Returns `{ ok: true, data }` on success or `{ ok: false }` when the fetch
+ * fails after retries. Distinguishing the two lets the orchestrator tell an
+ * absent field apart from a failed request, so failures never silently
+ * poison the dataset and a single bad recipe never aborts the run.
+ */
 module.exports = async (recipe) => {
-  return axios(encodeURI(recipe.link))
-    .then(async (response) => {
-      const html = response.data;
-      const $ = cheerio.load(html);
+  try {
+    const $ = await fetchHtml(recipe.link);
 
-      const getRecipeData = (sections) => {
-        let time;
-        let rations;
-        let difficulty;
+    const getRecipeData = (sections) => {
+      let time;
+      let rations;
+      let difficulty;
 
-        sections.each(function (key) {
-          if (key === 1) {
-            $(this)
-              .find('p')
-              .each(function () {
-                const text = $(this).text();
+      sections.each(function (key) {
+        if (key === 1) {
+          $(this)
+            .find('p')
+            .each(function () {
+              const text = $(this).text();
 
-                if (text.includes('Dificultad:')) {
-                  difficulty = text.split('Dificultad:')[1].trim();
-                } else if (text.includes('Raciones:')) {
-                  rations = text.split('Raciones:')[1].trim();
-                } else if (text.includes('Tiempo:')) {
-                  time = text.split('Tiempo:')[1].trim();
-                }
-              });
-          }
-        });
+              if (text.includes('Dificultad:')) {
+                difficulty = text.split('Dificultad:')[1].trim();
+              } else if (text.includes('Raciones:')) {
+                rations = text.split('Raciones:')[1].trim();
+              } else if (text.includes('Tiempo:')) {
+                time = text.split('Tiempo:')[1].trim();
+              }
+            });
+        }
+      });
 
-        return {
-          difficulty,
-          rations,
-          time,
-        };
+      return {
+        difficulty,
+        rations,
+        time,
       };
+    };
 
-      // Some recipes are inside recipes ...
-      if ($('.av-share-box').length) {
-        const newRecipeLink = $('a.avia-button').attr('href');
-        const $newRecipeHtml = await axios(encodeURI(newRecipeLink)).then(
-          (response) => {
-            return cheerio.load(response.data);
-          }
-        );
+    // Some recipes are inside recipes ...
+    if ($('.av-share-box').length) {
+      const newRecipeLink = $('a.avia-button').attr('href');
+      const $newRecipeHtml = await fetchHtml(newRecipeLink);
 
-        return {
+      return {
+        ok: true,
+        data: {
           ...getRecipeData(
             $newRecipeHtml('.entry-content-wrapper .av_textblock_section')
           ),
           image: $('.entry-content blockquote img').attr('src'),
-        };
-      } else {
-        return {
-          ...getRecipeData($('.entry-content-wrapper .av_textblock_section')),
-          image: $('.avia_image img').length
-            ? $('.avia_image img').attr('src')
-            : $('.avia_image').attr('src'),
-        };
-      }
-    })
-    .catch((error) => {
-      console.log(`
-            ${error}
-            \n
-            URL: ${recipe.link}
-        `);
-    });
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        ...getRecipeData($('.entry-content-wrapper .av_textblock_section')),
+        image: $('.avia_image img').length
+          ? $('.avia_image img').attr('src')
+          : $('.avia_image').attr('src'),
+      },
+    };
+  } catch (error) {
+    console.error(`Failed to fetch recipe ${recipe.link}: ${error.message}`);
+    return { ok: false };
+  }
 };

--- a/utils/node-scraper/modules/recipes-in-page.js
+++ b/utils/node-scraper/modules/recipes-in-page.js
@@ -1,37 +1,33 @@
-const axios = require('axios');
-const cheerio = require('cheerio');
+const { fetchHtml } = require('./http');
 
 /**
  * Given a page number returns the recipes in format:
  *   - title
  *   - link
+ *
+ * On failure it logs and returns an empty array so the orchestrator can skip
+ * this page and keep going instead of aborting the whole run.
  */
 module.exports = async (page) => {
   const url = `https://www.ollasgm.com/blog/page/${page}`;
 
-  return axios(url)
-    .then((response) => {
-      const html = response.data;
-      const $ = cheerio.load(html);
+  try {
+    const $ = await fetchHtml(url);
 
-      const recipes = [];
+    const recipes = [];
 
-      $('article.post').each(function () {
-        const titleElement = $(this).find('.post-title a');
+    $('article.post').each(function () {
+      const titleElement = $(this).find('.post-title a');
 
-        recipes.push({
-          title: titleElement.text().replace('en Olla GM', '').trim(),
-          link: titleElement.attr('href'),
-        });
+      recipes.push({
+        title: titleElement.text().replace('en Olla GM', '').trim(),
+        link: titleElement.attr('href'),
       });
-
-      return recipes;
-    })
-    .catch((error) => {
-      console.log(`
-                ${error}
-                \n
-                Página: ${page}
-            `);
     });
+
+    return recipes;
+  } catch (error) {
+    console.error(`Failed to fetch listing page ${page}: ${error.message}`);
+    return [];
+  }
 };

--- a/utils/node-scraper/modules/total-pages.js
+++ b/utils/node-scraper/modules/total-pages.js
@@ -1,17 +1,23 @@
-const axios = require('axios');
-const cheerio = require('cheerio');
+const { fetchHtml } = require('./http');
 
+const BLOG_URL = 'https://www.ollasgm.com/blog';
+
+/**
+ * Returns the total number of blog pages as an integer.
+ * Throws if the pagination cannot be parsed — the orchestrator treats this
+ * as a global failure and refuses to overwrite existing data.
+ */
 module.exports = async () => {
-  const url = 'https://www.ollasgm.com/blog';
+  const $ = await fetchHtml(BLOG_URL);
 
-  return axios(url)
-    .then((response) => {
-      const html = response.data;
-      const $ = cheerio.load(html);
+  const pagesMeta = $('.pagination .pagination-meta').text().trim().split(' ');
+  const totalPages = parseInt(pagesMeta[pagesMeta.length - 1], 10);
 
-      const pagesMeta = $('.pagination .pagination-meta').text().split(' ');
-      const totalPages = pagesMeta[pagesMeta.length - 1];
-      return totalPages;
-    })
-    .catch(console.error);
+  if (!Number.isInteger(totalPages) || totalPages < 1) {
+    throw new Error(
+      `Could not parse total pages from pagination meta: "${pagesMeta.join(' ')}"`
+    );
+  }
+
+  return totalPages;
 };

--- a/utils/node-scraper/script.js
+++ b/utils/node-scraper/script.js
@@ -1,41 +1,152 @@
 const fs = require('fs');
+const path = require('path');
 
 const getTotalRecipesPages = require('./modules/total-pages');
 const getRecipesInPage = require('./modules/recipes-in-page');
 const getRecipeData = require('./modules/recipe-data');
+const { mapWithConcurrency } = require('./modules/http');
+
+const DATA_PATH = path.resolve(__dirname, '../../data/recipes.json');
+
+// How many recipe detail pages to fetch at once. Keeps throughput steady
+// while staying polite to the origin server.
+const DETAIL_CONCURRENCY = 6;
+// How many listing pages to fetch at once.
+const LISTING_CONCURRENCY = 4;
+// Abort the write if more than this share of the fetched details failed —
+// a sign the whole site is blocking us rather than a few odd recipes.
+const MAX_FAILURE_RATE = 0.5;
+
+const isFullRun = process.argv.includes('--full');
+
+/** Loads the existing dataset as a Map keyed by link, or an empty Map. */
+const loadExistingRecipes = () => {
+  try {
+    const raw = fs.readFileSync(DATA_PATH, 'utf8');
+    const recipes = JSON.parse(raw);
+    return new Map(recipes.map((recipe) => [recipe.link, recipe]));
+  } catch {
+    return new Map();
+  }
+};
+
+/** Fetches every listing page and returns a de-duplicated list of links. */
+const collectListedRecipes = async (totalPages) => {
+  const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  const pages = await mapWithConcurrency(
+    pageNumbers,
+    LISTING_CONCURRENCY,
+    getRecipesInPage
+  );
+
+  let emptyPages = 0;
+  const byLink = new Map();
+
+  pages.forEach((pageRecipes) => {
+    if (!pageRecipes.length) {
+      emptyPages += 1;
+      return;
+    }
+    pageRecipes.forEach((recipe) => {
+      if (recipe.link && !byLink.has(recipe.link)) {
+        byLink.set(recipe.link, recipe);
+      }
+    });
+  });
+
+  return { listed: [...byLink.values()], emptyPages };
+};
 
 const getAndSaveAllRecipes = async () => {
-  const recipes = [];
+  const existing = isFullRun ? new Map() : loadExistingRecipes();
+  const previousCount = loadExistingRecipes().size;
+
+  console.log(
+    `--- Mode: ${isFullRun ? 'FULL' : 'incremental'} (${previousCount} recipes on disk) ---`
+  );
+
   const totalPages = await getTotalRecipesPages();
+  console.log(`--- Collecting links from ${totalPages} listing pages ---`);
 
-  for (let page = 1; page <= totalPages; page++) {
-    console.log(`--- Getting recipes from page ${page}/${totalPages} ---`);
-    const pageRecipes = await getRecipesInPage(page);
+  const { listed, emptyPages } = await collectListedRecipes(totalPages);
+  console.log(`--- Found ${listed.length} recipes in listing ---`);
 
-    console.log(`--- Map recipes with more data ---`);
-    const mappedRecipes = await Promise.all(
-      pageRecipes.map(getRecipeData)
-    ).then((recipesData) => {
-      return pageRecipes.map((recipe, key) => ({
-        ...recipe,
-        ...recipesData[key],
-      }));
-    });
+  const pending = listed.filter((recipe) => !existing.has(recipe.link));
+  console.log(`--- Fetching detail for ${pending.length} recipes ---`);
 
-    console.log(`--- Saved ${mappedRecipes.length} ---\n`);
-    recipes.push(...mappedRecipes);
+  const details = await mapWithConcurrency(
+    pending,
+    DETAIL_CONCURRENCY,
+    getRecipeData
+  );
+
+  const detailByLink = new Map();
+  let failed = 0;
+  pending.forEach((recipe, index) => {
+    const result = details[index];
+    detailByLink.set(recipe.link, result);
+    if (!result || !result.ok) {
+      failed += 1;
+    }
+  });
+
+  // Compose the final dataset in listing order, keeping known recipes and
+  // falling back to previous data (or title+link) when a detail fetch failed.
+  const finalByLink = new Map();
+  listed.forEach((recipe) => {
+    const detail = detailByLink.get(recipe.link);
+    const previous = existing.get(recipe.link);
+
+    if (detail && detail.ok) {
+      finalByLink.set(recipe.link, { ...recipe, ...detail.data });
+    } else if (previous) {
+      finalByLink.set(recipe.link, previous);
+    } else {
+      finalByLink.set(recipe.link, recipe);
+    }
+  });
+
+  // Carry over any previously known recipe missing from the listing (e.g. a
+  // listing page failed) so a partial run never drops good data.
+  existing.forEach((recipe, link) => {
+    if (!finalByLink.has(link)) {
+      finalByLink.set(link, recipe);
+    }
+  });
+
+  const recipes = [...finalByLink.values()];
+
+  console.log(
+    `\n--- Summary: ${recipes.length} total | ${pending.length - failed} new | ` +
+      `${failed} failed details | ${emptyPages} failed/empty pages ---`
+  );
+
+  // Safety guards: only block on global failures, never on odd recipes.
+  if (recipes.length === 0) {
+    console.error('Aborting: no recipes to write.');
+    process.exit(1);
   }
 
-  if (recipes.length === 0) {
+  if (recipes.length < previousCount) {
     console.error(
-      'No recipes were scraped — aborting without overwriting data/recipes.json'
+      `Aborting: recipe count would drop (${previousCount} -> ${recipes.length}).`
     );
     process.exit(1);
   }
 
-  fs.writeFileSync('./data/recipes.json', JSON.stringify(recipes, null, 2), {
-    flag: 'w+',
-  });
+  if (pending.length > 0 && failed / pending.length > MAX_FAILURE_RATE) {
+    console.error(
+      `Aborting: ${failed}/${pending.length} detail fetches failed (site likely blocking).`
+    );
+    process.exit(1);
+  }
+
+  fs.writeFileSync(DATA_PATH, JSON.stringify(recipes, null, 2), { flag: 'w+' });
+  console.log(`--- Wrote ${recipes.length} recipes to data/recipes.json ---`);
 };
 
-getAndSaveAllRecipes();
+getAndSaveAllRecipes().catch((error) => {
+  console.error(`Fatal error, data not written: ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Rework the OllasGM scraper for speed and reliability:

- Add shared axios client with timeout, browser User-Agent, retry with exponential backoff on transient errors, and a concurrency-limited map (new modules/http.js, no new dependencies).
- Incremental by default: reuse known recipes and only fetch details for new links; add --full flag and scraper:full script to force a full run.
- Fault tolerance: a failed recipe or listing page never aborts the run; recipe-data returns {ok} to tell an absent field from a failed fetch.
- Safe writes: abort only on global failures (empty result, dropping count, or >50% failed details) so partial runs never degrade the data.
- Robust total-pages parsing (validated integer).
- GitHub Actions: workflow_dispatch input to choose full vs incremental.